### PR TITLE
Write release manifest with LF line endings on all platforms

### DIFF
--- a/contributors/heyamei690-hash.md
+++ b/contributors/heyamei690-hash.md
@@ -1,0 +1,7 @@
+# heyamei690-hash
+
+I have read CLA.md version 1.0 and I agree to it.
+
+- GitHub: @heyamei690-hash
+- Date: 2026-09-04
+- Signing as: myself

--- a/scripts/check_release_manifest.py
+++ b/scripts/check_release_manifest.py
@@ -226,7 +226,7 @@ def write_manifest(root: Path) -> int:
 
     rows = {rel: hash_path(root, rel) for rel in tracked}
     body = "".join(f"{digest}  {rel}\n" for rel, digest in sorted(rows.items()))
-    (root / MANIFEST_NAME).write_text(HEADER + body, encoding="utf-8")
+    (root / MANIFEST_NAME).write_text(HEADER + body, encoding="utf-8", newline="\n")
     print(f"{MANIFEST_NAME}: wrote {len(rows)} row(s)")
     return 0
 


### PR DESCRIPTION
## Problem

On Windows, `scripts/check_release_manifest.py --write` rewrites every row of
`RELEASE_MANIFEST.txt` instead of only the rows for files that actually changed.

## Root cause

`write_manifest()` writes the manifest with
`(root / MANIFEST_NAME).write_text(...)`. `write_text()` opens the file in text
mode, so on Windows Python translates every `\n` in the content to `\r\n` on
the way out. The manifest is then hashed and compared as bytes, so every row
differs from the LF version held in the repository — a Windows contributor
following the documented workflow produces a whole-tree rewrite.

## Fix

Pass `newline="\n"` to `write_text()`, so the manifest is written with LF line
endings on every platform and produces identical bytes regardless of OS.

Fixes #32.

## Verification

On Windows 11, Python 3.12, uv:

$ uv run python -c "import tempfile,os; d=tempfile.mkdtemp(); f1=os.path.join(d,'a.txt'); f2=os.path.join(d,'b.txt'); open(f1,'w').write('x\ny\n'); open(f2,'w',newline='\n').write('x\ny\n'); print('without newline:', open(f1,'rb').read()); print('with newline=\n:', open(f2,'rb').read())"
without newline: b'x\r\ny\r\n'
with newline=\n: b'x\ny\n'

Without `newline`, Windows writes CRLF; with `newline="\n"` it writes LF — the
exact behaviour the fix relies on. The check script itself still runs and
reports correctly after the change.

## CLA

First PR — I have read CLA.md and added `contributors/heyamei690-hash.md` in
this PR.